### PR TITLE
HIP-1 SW 6.5: Fixed missing status update for orders with multiple transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 2.4.0
+
+- **Fix** : Fixed missing status update for orders with multiple transactions
+
 ## Version 2.3.0
 
 - **Add** : Added **Klarna** payment method

--- a/bin/docker/images/shopware/entrypoint.sh
+++ b/bin/docker/images/shopware/entrypoint.sh
@@ -28,7 +28,7 @@ sudo mysql -u root --password=root -D shopware -e "update shipping_method s inne
 echo "-----------------------------------------------------"
 echo "ACTIVATING HIPAY PAYMENT MODULE"
 # Activate custom module
-composer require hipay/hipay-fullservice-sdk-php giggsey/libphonenumber-for-php
+composer require hipay/hipay-fullservice-sdk-php giggsey/libphonenumber-for-php:^8.13
 bin/console plugin:refresh --quiet
 bin/console plugin:install --activate HiPayPaymentPlugin
 bin/console cache:clear --quiet

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
       - './reports:/var/www/html/custom/plugins/HiPayPaymentPlugin/reports'
       - './composer.json:/var/www/html/custom/plugins/HiPayPaymentPlugin/composer.json'
       - './log:/var/www/html/var/log'
-      - './vendor:/var/www/html/vendor'
   proxy:
     container_name: proxy
     image: dockware/proxy:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       - './reports:/var/www/html/custom/plugins/HiPayPaymentPlugin/reports'
       - './composer.json:/var/www/html/custom/plugins/HiPayPaymentPlugin/composer.json'
       - './log:/var/www/html/var/log'
+      - './vendor:/var/www/html/vendor'
   proxy:
     container_name: proxy
     image: dockware/proxy:latest

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -384,6 +384,10 @@ class NotificationService
                     );
                 }
 
+                if ($stateMachine === OrderTransactionStates::STATE_FAILED) {
+                    $this->orderTransactionStateHandler->reopen($hipayOrder->getTransactionId(), $context);
+                }
+
                 $this->orderTransactionStateHandler->authorize($hipayOrder->getTransactionId(), $context);
                 $this->handleSepaAuthorizedNotification($notification, $hipayOrder);
                 $statusChange = true;


### PR DESCRIPTION
**1. Why is this change necessary?**

- Payments are stuck in progress state in case of order with multiple transactions after the user uses a valid credit card
- The reason is the missing state transition "reopen" which has to be made before "authorize" 

**2. What does this change do, exactly?**

- Add a "reopen" state transition before authorizing if an order has a previous failed transaction
- The giggsey/libphonenumber-for-php have an specific version range attached due to its latest major version update 9.x which is supported on Shopware 6.6

**3. Relevant tickets.**

- [HIP-001](https://basecom-gmbh.atlassian.net/browse/HIP-001)